### PR TITLE
Added flashcart-decompiler.py and flashcart-trimmer.py

### DIFF
--- a/flashcart-decompiler.py
+++ b/flashcart-decompiler.py
@@ -1,0 +1,204 @@
+print("\nArduboy Flashcart image decompiler v0.1 by JJCooley Nov 2020\n")
+
+# Applying the "menu patch" when building may make original .hex different from decompiled .hex (multiple recompiles/decompiles will yield the same file after this)
+
+# requires PILlow. Use 'python -m pip install pillow' to install
+
+import sys
+import time
+import os
+import csv
+import math
+import shutil
+try:
+  from PIL import Image
+except:
+  print("The PILlow module is required but not installed!")
+  print("Use 'python -m pip install pillow' from the commandline to install.")
+  sys.exit()
+
+# Array indices
+CATEGORY_INDEX = 0
+PROGRAM_INDEX = 1
+TITLE_IMAGE_INDEX = 2
+PROGRAM_HEXFILE_INDEX = 3
+DATAFILE_INDEX = 4
+
+# CSV IDs
+ID_LIST  = 0
+ID_TITLE = 1
+ID_TITLESCREEN = 2
+ID_HEXFILE = 3
+ID_DATAFILE = 4
+ID_SAVEFILE = 5
+
+HEADER_LENGTH = 256
+TITLE_IMAGE_LENGTH = 1024
+
+SLOT_SIZE_HEADER_INDEX = 12
+CATEGORY_HEADER_INDEX = 7
+PROGRAM_SIZE_HEADER_INDEX = 14
+
+HEADER_START_BYTES = bytearray("ARDUBOY".encode())
+
+def GetBit(byte, index):
+    return byte&(2**index) != 0
+
+def IntToHex(intNum, placesToFill):
+    hexString = hex(intNum).replace("0x", "").upper()
+    hexString = "0"*(placesToFill-len(hexString)) + hexString
+    return hexString
+
+def DecompileTitleScreenData(byteData):
+    byteLength = len(byteData)
+    pixels = bytearray(8192)
+    for b in range(0, byteLength):
+        for i in range(0, 8):
+            yPos = b//128*8+i
+            xPos = b%128
+            pixels[yPos * 128 + xPos] = 255 if GetBit(byteData[b], i) else 0
+
+    img = Image.frombytes("L", (128, 64), bytes(pixels))
+
+    return img
+
+def DecompileHexFileData(byteData):
+    byteLength = len(byteData)
+
+    hexData = []
+    for byteNum in range(0, byteLength, 16):
+        hexLine = ":10" + IntToHex(byteNum, 4) + "00"
+        for i in range(0, 16):
+            if byteNum+i > byteLength-1:
+                break
+            hexLine += IntToHex(byteData[byteNum+i], 2)
+        lineSum = 0
+        for i in range(1, 41, 2):
+            hexByte = hexLine[i] + hexLine[i+1]
+            lineSum += int(hexByte, 16)
+
+        checkSum = 256-lineSum%256
+        if checkSum == 256:
+            checkSum = 0
+        hexLine += IntToHex(checkSum, 2)
+        hexData.append(hexLine)
+
+    if byteLength%16 > 0:
+        lineSum = (byteLength%16) + (byteLength-byteLength%16)
+        hexLine = ":" + IntToHex(byteLength%16, 2) + IntToHex(byteLength-byteLength%16, 4) + "00"
+        for i in range(0, byteLength%16):
+            lineSum += int(byteData[byteLength-byteLength%16+i])
+            hexLine += IntToHex(int(byteData[byteLength-byteLength%16+i]))
+        hexLine += IntToHex(256-lineSum%256, 2)
+        hexData.append(hexLine)
+
+    fullHexString = ""
+    for hexLine in range(0, len(hexData)):
+        fullHexString += hexData[hexLine]
+        if hexLine != len(hexData)-1:
+            fullHexString += "\n"
+
+    return fullHexString
+
+
+def GetProgramSections(fullBinaryData):
+    # Use header[14]*128 to determine program size
+    # Use header[12] concat header[13] to int, * 2*128 to determine slot size (header (256) + title (1024) + program + data)
+    # Use header[7] to determine category number
+
+    programDataArray = []
+
+    currentHeaderIndex = 0
+    previousCategory = 0
+    programIndex = 0
+    while currentHeaderIndex < len(fullBinaryData)-1:
+        if HEADER_START_BYTES != fullBinaryData[currentHeaderIndex:currentHeaderIndex+len(HEADER_START_BYTES)]:
+            break
+
+        programCategory = fullBinaryData[currentHeaderIndex+CATEGORY_HEADER_INDEX]
+        titleImageData = fullBinaryData[currentHeaderIndex+HEADER_LENGTH:currentHeaderIndex+HEADER_LENGTH+TITLE_IMAGE_LENGTH]
+        programData = fullBinaryData[currentHeaderIndex+HEADER_LENGTH+TITLE_IMAGE_LENGTH:currentHeaderIndex+HEADER_LENGTH+TITLE_IMAGE_LENGTH+fullBinaryData[currentHeaderIndex+PROGRAM_SIZE_HEADER_INDEX]*128]
+
+        if previousCategory != programCategory:
+            programIndex = 0
+
+        programDataArray.append([programCategory, programIndex, titleImageData, programData])
+
+        currentHeaderIndex += ((fullBinaryData[currentHeaderIndex+SLOT_SIZE_HEADER_INDEX] << 8) + fullBinaryData[currentHeaderIndex+SLOT_SIZE_HEADER_INDEX+1])*2*128
+
+        previousCategory = programCategory
+        programIndex += 1
+
+    print("Found {} program sections".format(len(programDataArray)))
+
+    return programDataArray
+
+def DecompileProgramParts(programSections):
+    decompiledProgramData = []
+
+    print("-"*6 + "  " + "-"*7 + "  " + "-"*8 + "  " + "-"*5 + "  " + "-"*12)
+    print("% Done  Abs Pos  Category  Index  Program Size")
+
+    for programAbsoluteIndex in range(0, len(programSections)):
+        programData = programSections[programAbsoluteIndex]
+
+        decompiledProgramData.append([programData[CATEGORY_INDEX], programData[PROGRAM_INDEX], DecompileTitleScreenData(programData[TITLE_IMAGE_INDEX]), DecompileHexFileData(programData[PROGRAM_HEXFILE_INDEX])])
+
+        print("{:7} {:7} {:9} {:6} {:13}".format(str(round(100*programAbsoluteIndex/(len(programSections)-1), 2))+"%", programAbsoluteIndex, programData[CATEGORY_INDEX], programData[PROGRAM_INDEX], len(programData[PROGRAM_HEXFILE_INDEX])))
+
+    print("-"*6 + "  " + "-"*7 + "  " + "-"*8 + "  " + "-"*5 + "  " + "-"*12)
+    print("% Done  Abs Pos  Category  Index  Program Size")
+
+    return decompiledProgramData
+
+def WriteDecompiledProgramData(decompiledProgramData):
+    decompiledPath = os.path.splitext(sys.argv[1])[0]
+
+    if (os.path.isdir(decompiledPath)):
+        shutil.rmtree(decompiledPath)
+    os.mkdir(decompiledPath)
+
+    indexCSVString = "List;Discription;Title screen;Hex file;Data file;Save file"
+
+    for programDataIndex in range(0, len(decompiledProgramData)):
+        categoryIndex = str(decompiledProgramData[programDataIndex][CATEGORY_INDEX])
+        programIndex = str(decompiledProgramData[programDataIndex][PROGRAM_INDEX])
+
+        categoryDirPath = os.path.join(decompiledPath, categoryIndex)
+        programDirPath = os.path.join(os.path.join(decompiledPath, categoryIndex), programIndex)
+        if not os.path.isdir(categoryDirPath):
+            os.mkdir(categoryDirPath)
+        if not os.path.isdir(programDirPath):
+            os.mkdir(programDirPath)
+
+        titleImagePath = os.path.join(programDirPath, programIndex + ".png")
+        decompiledProgramData[programDataIndex][TITLE_IMAGE_INDEX].save(titleImagePath)
+
+        shouldIncludeHexFile = len(decompiledProgramData[programDataIndex][PROGRAM_HEXFILE_INDEX]) > 0
+        if shouldIncludeHexFile:
+            hexFilePath = os.path.join(programDirPath, programIndex + ".hex")
+            hexFile = open(hexFilePath, 'w')
+            hexFile.write(decompiledProgramData[programDataIndex][PROGRAM_HEXFILE_INDEX])
+            hexFile.close()
+
+        indexCSVString += "\n"
+        indexCSVString += categoryIndex + ";"
+        indexCSVString += categoryIndex + "-" + programIndex + ";"
+        indexCSVString += os.path.join(os.path.join(categoryIndex, programIndex), programIndex + ".png") + ";"
+        indexCSVString += (os.path.join(os.path.join(categoryIndex, programIndex), programIndex + ".hex") if shouldIncludeHexFile else "") + ";"
+        indexCSVString += ";"
+
+    indexCSVFile = open(os.path.join(decompiledPath, "flashcart-index.csv"), 'w')
+    indexCSVFile.write(indexCSVString)
+
+
+if len(sys.argv) != 2:
+    print("\nUsage: {} flashcart-image.bin\n".format(os.path.basename(sys.argv[0])))
+    sys.exit()
+
+flashcartBinFile = open(sys.argv[1], 'rb')
+flashcartBinData = flashcartBinFile.read()
+
+programSections = GetProgramSections(flashcartBinData)
+decompiledProgramData = DecompileProgramParts(programSections)
+WriteDecompiledProgramData(decompiledProgramData)

--- a/flashcart-trimmer.py
+++ b/flashcart-trimmer.py
@@ -1,0 +1,37 @@
+print("\nArduboy Flashcart image trimmer v0.1 by JJCooley Nov 2020\n")
+
+import sys
+import os
+
+SLOT_SIZE_HEADER_INDEX = 12
+
+HEADER_START_BYTES = bytearray("ARDUBOY".encode())
+
+def GetTrimmedBinaryData(fullBinaryData):
+    # Use header[12] concat header[13] to int, * 2*128 to determine slot size (header (256) + title (1024) + program + data)
+
+    currentHeaderIndex = 0
+    while currentHeaderIndex < len(fullBinaryData)-1:
+        if HEADER_START_BYTES != fullBinaryData[currentHeaderIndex:currentHeaderIndex+len(HEADER_START_BYTES)]:
+            break
+
+        slotByteSize = ((fullBinaryData[currentHeaderIndex+SLOT_SIZE_HEADER_INDEX] << 8) + fullBinaryData[currentHeaderIndex+SLOT_SIZE_HEADER_INDEX+1])*2*128
+        currentHeaderIndex += slotByteSize
+
+    print("Trimming {}/{}".format(currentHeaderIndex, len(fullBinaryData)))
+
+    return fullBinaryData[0:currentHeaderIndex]
+
+if len(sys.argv) != 2:
+    print("\nUsage: {} flashcart-image.bin\n".format(os.path.basename(sys.argv[0])))
+    sys.exit()
+
+flashcartBinFile = open(sys.argv[1], 'rb')
+binaryData = flashcartBinFile.read()
+flashcartBinFile.close()
+
+trimmedBinData = GetTrimmedBinaryData(binaryData)
+
+flashcartBinFile = open(sys.argv[1], 'wb')
+flashcartBinFile.write(trimmedBinData)
+flashcartBinFile.close()


### PR DESCRIPTION
# flashcart-decompiler.py: 

Decompiles flashcart binaries into a page: image & program hex folder structure as seen below:

&nbsp;root
├──0 (page #)
&nbsp;│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└──0 (program #, 0 will usually be just an image for that page)
&nbsp;│&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└──0.png (cover image)
├──1
&nbsp;│ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├──0
&nbsp;│ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; │ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└──0.png
&nbsp;│ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├──1
&nbsp;│ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; │ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├──1.hex (actual compiled program hex file)
&nbsp;│ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; │ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└──1.png
......
└── flashcart-index.csv (csv containing relative paths to all image/hex files, for easy rebuild)

This can be useful if you want to decompile a backup binary and add new pages / images / programs, then build and upload back to the Arduboy.

# flashcart-trimmer.py:

Removes the extra trailing 0s space from backup binaries, which can reduce the size by several MBs. 

The trimmer checks for the "ARDUBOY" tag at beginning of each program and will trim the remainder of the binary file once the tag is not found at the next expected program address.